### PR TITLE
feat(handler): add a generic handler wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ func main() {
 		zlog.New(zlog.Fields(flds)), // inject zerolog into the context
 	).ThenFunc(processEvent)
 
-	lambda.StartHandler(ch)
+	// use StartWithOptions as StartHandler is deprecated 
+	lambda.StartWithOptions(ch)
 }
 
 func processEvent(ctx context.Context, payload []byte) ([]byte, error) {

--- a/example/main.go
+++ b/example/main.go
@@ -23,7 +23,7 @@ func main() {
 		zlog.New(zlog.Fields(flds)), // inject zerolog into the context
 	).ThenFunc(processEvent)
 
-	lambda.StartHandler(ch)
+	lambda.StartWithOptions(ch)
 }
 
 func processEvent(ctx context.Context, payload []byte) ([]byte, error) {

--- a/lambdaextras/lambdaextras.go
+++ b/lambdaextras/lambdaextras.go
@@ -1,7 +1,10 @@
 // Package lambdaextras contains extras for building Go based lambdas.
 package lambdaextras
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 // The HandlerFunc type is an adapter to allow the use of
 // ordinary functions as Lambda Handlers. If f is a function
@@ -12,4 +15,23 @@ type HandlerFunc func(ctx context.Context, payload []byte) ([]byte, error)
 // Invoke calls f(ctx, payload).
 func (f HandlerFunc) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
 	return f(ctx, payload)
+}
+
+// GenericHandler converts a typed lambda handler into a Handler func
+func GenericHandler[I any, O any](handler func(context.Context, I) (O, error)) HandlerFunc {
+	return func(ctx context.Context, payload []byte) ([]byte, error) {
+		var input I
+
+		err := json.Unmarshal(payload, &input)
+		if err != nil {
+			return nil, err
+		}
+
+		output, err := handler(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(&output)
+	}
 }

--- a/lambdaextras/lambdaextras_test.go
+++ b/lambdaextras/lambdaextras_test.go
@@ -19,3 +19,23 @@ func TestHandlerFunc(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal([]byte("world"), data)
 }
+
+type In struct {
+	Msg string `json:"msg,omitempty"`
+}
+
+type Out struct {
+	Result string `json:"result,omitempty"`
+}
+
+func TestGenericHandler(t *testing.T) {
+	assert := require.New(t)
+
+	h := GenericHandler(func(ctx context.Context, input In) (Out, error) {
+		return Out{Result: input.Msg}, nil
+	})
+
+	data, err := h.Invoke(context.TODO(), []byte(`{"msg": "hello"}`))
+	assert.NoError(err)
+	assert.Equal([]byte(`{"result":"hello"}`), data)
+}


### PR DESCRIPTION
This new generic method removes a bit of the boilerplate which I have found myself adding to each handler and replaces it with a generic alternative.